### PR TITLE
[FIX] removed .Site.BaseURL from header/404/single

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,7 +3,7 @@
   <article class="post">
     <h1>404 Not Found</h1>
     <p>Sorry, but we couldn't find the page you're looking for.</p>
-    <p>Please head back <a href="{{ .Site.BaseURL }}">home</a>.</p>
+    <p>Please head back <a href="/">home</a>.</p>
   </article>
 </main>
 {{ partial "foot.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,7 @@
 <!-- <main class="posts"> -->
 <main>
 <article class="post">
-  <h1><a href="{{ .Site.BaseURL }}{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
+  <h1><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
   {{ .Content }}
   <p class="small gray"><time datetime="{{ .Date.Format "2006-01-30" }}">{{ .Date.Format "Jan 01, 2006" }}</time></p>
 </article>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,11 +8,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   
   <!-- Icons -->
-  <link rel="icon" href="{{ .Site.BaseURL }}/favicon.png" />
-  <link rel="apple-touch-icon-precomposed" href="{{ .Site.BaseURL }}/apple-touch-icon.png" />
+  <link rel="icon" href="/favicon.png" />
+  <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon.png" />
   
   <!-- Style & Font -->
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/style.css" />
+  <link rel="stylesheet" href="/style.css" />
   <link href='//fonts.googleapis.com/css?family=Merriweather:400,700' rel='stylesheet' type='text/css'>
 
 </head>
@@ -20,6 +20,6 @@
 
   <div class="wrap">
     <header class="mb">
-      <h1 class="h2 m-0"><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
+      <h1 class="h2 m-0"><a href="/">{{ .Site.Title }}</a></h1>
       <p>{{ .Site.Params.description }}</p>
     </header>


### PR DESCRIPTION
The theme is throwing `BaseURL is not a field of struct type
*hugolib.SiteInfo` errors currently with v0.13 of Hugo.

See https://github.com/spf13/hugo/issues/751
