### PR TITLE
Bare keys cannot contain ':'. for heather-hugo.md.

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -1,7 +1,7 @@
 name = "Heather Hugo"
 license = "MIT"
 licenselink = "//opensource.org/licenses/MIT"
-description: A Hyperminimal J̶e̶k̶y̶l̶l̶ Hugo Theme
+description = "A Hyperminimal J̶e̶k̶y̶l̶l̶ Hugo Theme"
 homepage = "hbpasti.github.io/heather-hugo"
 tags = ["blog"]
 features = ["blog"]


### PR DESCRIPTION
This was causing the [hugo theme site](https://github.com/spf13/hugoThemeSiteScript) to not build.
