### PR TITLE
fix error on date

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 <article class="post">
   <h1><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
   {{ .Content }}
-  <p class="small gray"><time datetime="{{ .Date.Format "2006-01-30" }}">{{ .Date.Format "Jan 01, 2006" }}</time></p>
+  <p class="small gray"><time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 02, 2006" }}</time></p>
 </article>
 </main>
 {{ partial "foot.html" . }}


### PR DESCRIPTION
Found there is error on date template.
The value of day should be 2 not 30 or 01.

Ref.
https://godoc.org/time#Parse
