### PR TITLE
Add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ for [Jekyll](//jekyllrb.com) created by Brent Jackson
 
 [Hugo](//gohugo.io) is a (very) fast static site generator written in Go.
 
+Compatible with hugo [0.15.0](http://gohugo.io/meta/release-notes/)
+
 ## Get Started
 
 Once you have Hugo set up, create your blog with `hugo new` and then
@@ -38,7 +40,7 @@ Then edit your blog's config file to use heather-hugo theme:
     theme: "heather-hugo"
     ```
 
-A sample YAML config file would look like this:
+For example, a minimal YAML config file looks like this:
 
     title: "Heather"
     baseurl: "http://localhost:1313"
@@ -56,6 +58,7 @@ A sample YAML config file would look like this:
       author: 
         name: "Hbpasti"
         email: "your@email.com"
+      readMoreLabel: "Read more"
     ...
 
 ---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,10 +1,16 @@
+
 {{ partial "head.html" . }}
 <main class="posts">
   <article class="post">
     {{ range .Data.Pages }}
-    <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-    <p>{{ .Summary }}</p>
-    <p class="small"><a href="{{ .Permalink }}">{{ .Site.Params.readMoreLabel }} »</a></p>
+      <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+      <p>{{ .Summary }}</p>
+      <!-- Support heather-hugo users who have not yet added the "Read more" label option to their site config. -->
+      {{ if isset .Site.Params "readMoreLabel" }}
+        <p class="small"><a href="{{ .Permalink }}">{{ .Site.Params.readMoreLabel }} »</a></p>
+      {{ else }}
+        <p class="small"><a href="{{ .Permalink }}">Read more »</a></p>
+      {{ end }}
     {{ end }}
   </article>
 </main>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
     {{ range .Data.Pages }}
     <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
     <p>{{ .Summary }}</p>
-    <p class="small"><a href="{{ .Permalink }}">Read More »</a></p>
+    <p class="small"><a href="{{ .Permalink }}">{{ .Site.Params.readMoreLabel }} »</a></p>
     {{ end }}
   </article>
 </main>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,3 +1,15 @@
 </div>
+
+{{ if or (isset .Site.Params "FooterGraphic") (isset .Site.Params "FooterText") }}
+<footer class="center">
+  {{ if isset .Site.Params "FooterHTML" }}
+  <p> {{ .Site.Params.FooterHTML | safeHTML }} </p>
+  {{ end }}
+  {{ if isset .Site.Params "FooterGraphic" }}
+  <img src="{{ .Site.BaseURL }}{{ .Site.Params.FooterGraphic }}" alt="{{ .Site.Params.FooterGraphicAlt }}" title="{{ .Site.Params.FooterGraphicTitle }}"/>
+  {{ end }}
+</footer>
+{{ end }}
+
 </body>
 </html>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,12 +1,12 @@
 </div>
 
-{{ if or (isset .Site.Params "FooterGraphic") (isset .Site.Params "FooterText") }}
+{{ if or (isset .Site.Params "footerGraphic") (isset .Site.Params "footerHTML") }}
 <footer class="center">
-  {{ if isset .Site.Params "FooterHTML" }}
-  <p> {{ .Site.Params.FooterHTML | safeHTML }} </p>
+  {{ if isset .Site.Params "footerHTML" }}
+  <p> {{ .Site.Params.footerHTML | safeHTML }} </p>
   {{ end }}
-  {{ if isset .Site.Params "FooterGraphic" }}
-  <img src="{{ .Site.BaseURL }}{{ .Site.Params.FooterGraphic }}" alt="{{ .Site.Params.FooterGraphicAlt }}" title="{{ .Site.Params.FooterGraphicTitle }}"/>
+  {{ if isset .Site.Params "footerGraphic" }}
+  <img src="{{ .Site.BaseURL }}{{ .Site.Params.footerGraphic }}" alt="{{ .Site.Params.footerGraphicAlt }}" title="{{ .Site.Params.footerGraphicTitle }}"/>
   {{ end }}
 </footer>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,7 @@
 
 </head>
 
-<body class="{{ with .Site.Params.PageLayoutClass }}{{ . }}{{ end }}">
+<body class="{{ with .Site.Params.pageLayoutClass }}{{ . }}{{ end }}">
 
   {{ if or (isset .Site.Params "headerGraphic") (isset .Site.Params "headerHTML") }}
   <div class="header center">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,9 +11,12 @@
   <link rel="icon" href="/favicon.png" />
   <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon.png" />
   
-  <!-- Style & Font -->
+  <!-- CSS Style -->
   <link rel="stylesheet" href="/style.css" />
+  {{ if eq .Site.Params.GoogleFont true }}
+  <!-- Load Google Font Merriweather -->
   <link href='//fonts.googleapis.com/css?family=Merriweather:400,700' rel='stylesheet' type='text/css'>
+  {{ end }}
 
 </head>
 <body>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,6 +13,9 @@
   
   <!-- CSS Style -->
   <link rel="stylesheet" href="/style.css" />
+  {{ if isset .Site.Params "CustomCSS" }}
+  <link href='{{.Site.BaseURL}}{{.Site.Params.CustomCSS}}' rel='stylesheet' type='text/css'>
+  {{ end }}
   {{ if eq .Site.Params.GoogleFont true }}
   <!-- Load Google Font Merriweather -->
   <link href='//fonts.googleapis.com/css?family=Merriweather:400,700' rel='stylesheet' type='text/css'>
@@ -24,5 +27,5 @@
   <div class="wrap">
     <header class="mb">
       <h1 class="h2 m-0"><a href="/">{{ .Site.Title }}</a></h1>
-      <p>{{ .Site.Params.description }}</p>
+      <p>{{ .Site.Params.Description }}</p>
     </header>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,7 +22,21 @@
   {{ end }}
 
 </head>
+
 <body class="{{ with .Site.Params.PageLayoutClass }}{{ . }}{{ end }}">
+
+  {{ if or (isset .Site.Params "HeaderGraphic") (isset .Site.Params "HeaderHTML") }}
+  <div class="header center">
+    {{ if isset .Site.Params "HeaderHTML" }}
+    <p> {{ .Site.Params.HeaderHTML | safeHTML }} </p>
+    {{ end }}
+    {{ if isset .Site.Params "HeaderGraphic" }}
+    <a href="/">
+      <img src="{{ .Site.BaseURL }}{{ .Site.Params.HeaderGraphic }}" alt="{{ .Site.Params.HeaderGraphicAlt }}" title="{{ .Site.Params.HeaderGraphicTitle }}"/>
+    </a>
+    {{ end }}
+  </div>
+  {{ end }}
 
   <div class="wrap">
     <header class="mb">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,10 +13,10 @@
   
   <!-- CSS Style -->
   <link rel="stylesheet" href="/style.css" />
-  {{ if isset .Site.Params "CustomCSS" }}
-  <link href='{{ .Site.BaseURL }}{{ .Site.Params.CustomCSS }}' rel='stylesheet' type='text/css'>
+  {{ if isset .Site.Params "customCSS" }}
+  <link href='{{ .Site.BaseURL }}{{ .Site.Params.customCSS }}' rel='stylesheet' type='text/css'>
   {{ end }}
-  {{ if eq .Site.Params.GoogleFont true }}
+  {{ if eq .Site.Params.googleFont true }}
   <!-- Load Google Font Merriweather -->
   <link href='//fonts.googleapis.com/css?family=Merriweather:400,700' rel='stylesheet' type='text/css'>
   {{ end }}
@@ -25,14 +25,14 @@
 
 <body class="{{ with .Site.Params.PageLayoutClass }}{{ . }}{{ end }}">
 
-  {{ if or (isset .Site.Params "HeaderGraphic") (isset .Site.Params "HeaderHTML") }}
+  {{ if or (isset .Site.Params "headerGraphic") (isset .Site.Params "headerHTML") }}
   <div class="header center">
-    {{ if isset .Site.Params "HeaderHTML" }}
-    <p> {{ .Site.Params.HeaderHTML | safeHTML }} </p>
+    {{ if isset .Site.Params "headerHTML" }}
+    <p> {{ .Site.Params.headerHTML | safeHTML }} </p>
     {{ end }}
-    {{ if isset .Site.Params "HeaderGraphic" }}
+    {{ if isset .Site.Params "headerGraphic" }}
     <a href="/">
-      <img src="{{ .Site.BaseURL }}{{ .Site.Params.HeaderGraphic }}" alt="{{ .Site.Params.HeaderGraphicAlt }}" title="{{ .Site.Params.HeaderGraphicTitle }}"/>
+      <img src="{{ .Site.BaseURL }}{{ .Site.Params.headerGraphic }}" alt="{{ .Site.Params.headerGraphicAlt }}" title="{{ .Site.Params.headerGraphicTitle }}"/>
     </a>
     {{ end }}
   </div>
@@ -41,5 +41,5 @@
   <div class="wrap">
     <header class="mb">
       <h1 class="h2 m-0"><a href="/">{{ .Site.Title }}</a></h1>
-      <p class="site-description">{{ .Site.Params.Description }}</p>
+      <p class="site-description">{{ .Site.Params.description }}</p>
     </header>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
   <!-- CSS Style -->
   <link rel="stylesheet" href="/style.css" />
   {{ if isset .Site.Params "CustomCSS" }}
-  <link href='{{.Site.BaseURL}}{{.Site.Params.CustomCSS}}' rel='stylesheet' type='text/css'>
+  <link href='{{ .Site.BaseURL }}{{ .Site.Params.CustomCSS }}' rel='stylesheet' type='text/css'>
   {{ end }}
   {{ if eq .Site.Params.GoogleFont true }}
   <!-- Load Google Font Merriweather -->
@@ -22,10 +22,10 @@
   {{ end }}
 
 </head>
-<body>
+<body class="{{ with .Site.Params.PageLayoutClass }}{{ . }}{{ end }}">
 
   <div class="wrap">
     <header class="mb">
       <h1 class="h2 m-0"><a href="/">{{ .Site.Title }}</a></h1>
-      <p>{{ .Site.Params.Description }}</p>
+      <p class="site-description">{{ .Site.Params.Description }}</p>
     </header>

--- a/static/style.css
+++ b/static/style.css
@@ -23,6 +23,8 @@ body {
   font-family: 'Merriweather', serif;
 }
 
+footer p { text-align: left; }
+
 h1, h2, h3, h4, h5, h6 { line-height: 1.25; }
 h1, .h1 {
   font-size: 32px;
@@ -48,6 +50,7 @@ a { color: #09c; text-decoration: none; }
 a:hover { color: #069; }
 h1 a { color: #333;}
 
+footer p,
 .wrap {
   width: 90%;
   max-width: 768px;

--- a/static/style.css
+++ b/static/style.css
@@ -23,7 +23,7 @@ body {
   font-family: 'Merriweather', serif;
 }
 
-footer p { text-align: left; }
+.header p, footer p { text-align: left; }
 
 h1, h2, h3, h4, h5, h6 { line-height: 1.25; }
 h1, .h1 {

--- a/static/style.css
+++ b/static/style.css
@@ -34,6 +34,8 @@ h2, .h2, h3, .h3, h4, h5, h6 {
   font-size: 24px;
   margin-bottom: 16px;
 }
+article ol,
+article ul,
 p, .p {
   font-size: 18px;
   margin-bottom: 32px;


### PR DESCRIPTION
Hi there!

First and foremost let me say thank you all contributors for porting and making this nice theme availabe for me as a hugo user. I do like this theme not only for its minimalistic approach but mostly because of that as i see it as something to build upon. I could not dig through all of the other themes but this was the only one i found which did not deliver lots of dependency files.

Now, i do not intend (A) to touch the minimal configuration required to get started with this theme and when i do introduce changes i always try to make sure that (B) changes are handled in a way that it does not affect all existing users who simply do not want or need any other additional configuration options.

That said, with this PR i want to introduce some very simple but powerful options for configuring this theme. Here is the complete list of the what i came up with and needed for my new hugo-site dressed in `heather-hugo` (written in TOML):

```
googleFont = false|true
readMoreLabel = "Read more"
customCSS = "/styles/custom.css"
headerHTML = "Good Morning, here we have some HTML for you."
headerGraphic = "/images/rocket.png"
headerGraphicTitle = "Cheerio, Rocket Science"
headerGraphicAlt = "Image of a Rocket - our Logo"
footerHTML = "All contents published on this page are released into the <a href=\"\">Public Domain</a>."
footerGraphic = "/images/rocket.png"
footerGraphicTitle = "Cheerio, Rocket Science"
footerGraphicAlt = "Image of a Rocket - our Logo
```

This allows for simple toggling the Google Font Usage, Internationalization of the "Read more" button on the front page, loading theme customizations from a custom stylesheet path and introduces the possibility to configure a very minimalistic (page-wide) header (above) and footer (below page content) area.

To soften up the introduction of the "readMoreLabel" option i implemented it the way that existing users, missing that option in their site configuration end up with the hard-coded "Read more" value. This introduces all the new theme options added here really optional to use. I added a compatibility note to the README that this is just tested to work with hugo in version 0.15 (as i am unaware of the recent changes to the template syntax in hugo) but it should work down to 0.13 or even further, i guess.

Cheers!
