### PR TITLE
[FIX] Have each post on index be displayed between article tags

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,8 @@
 
 {{ partial "head.html" . }}
 <main class="posts">
+  {{ range .Data.Pages }}
   <article class="post">
-    {{ range .Data.Pages }}
       <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
       <p>{{ .Summary }}</p>
       <!-- Support heather-hugo users who have not yet added the "Read more" label option to their site config. -->
@@ -11,7 +11,7 @@
       {{ else }}
         <p class="small"><a href="{{ .Permalink }}">Read more »</a></p>
       {{ end }}
-    {{ end }}
   </article>
+  {{ end }}
 </main>
 {{ partial "foot.html" . }}


### PR DESCRIPTION
Whilst inspecting the index page I noticed that each post preview was contained within a pair of main tags (as expected), however all post elements were also contained within one single pair of article tags. Judging by the class name (post), the intended implementation would have been to render each article preview between it's own pair of article tags. In addition, this can be confirmed by checking the implementation before and after the Hugo port.

![index_compare](https://cloud.githubusercontent.com/assets/6503216/20734857/299fd93e-b694-11e6-973c-57bf668c90f4.jpg)

![code_screenshot](https://cloud.githubusercontent.com/assets/6503216/20734856/299f0680-b694-11e6-9206-f9c13178245c.png)

